### PR TITLE
GitHub Pages対応（静的エクスポート・デプロイ手順追加）

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,20 @@ Google Fit の REST API を利用し、過去 1 週間分の歩数データを�
 -   Tailwind CSS + daisyUI
 -   Chart.js
 
-## デプロイ
+## デプロイ（GitHub Pages対応）
 
--   GitHub Pages 等で静的デプロイ可能
+1. `next.config.js` で `output: 'export'`、`basePath`、`assetPrefix` を設定済み
+2. 静的エクスポート
+    ```bash
+    npm run build && npm run export
+    ```
+    - `out/` ディレクトリが生成される
+3. GitHub Pages の公開設定で `out/` ディレクトリを指定
+    - GitHubリポジトリの「Settings」→「Pages」→「Source」で`/out`を選択
+4. 本番URL例: `https://ユーザー名.github.io/google-fit-steps/`
+
+- ルート以外のページで404になる場合は`404.html`が自動生成されるので対応可
+- `basePath`/`assetPrefix`はリポジトリ名に合わせて自動設定
 
 ## ライセンス
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,15 @@
+/** @type {import('next').NextConfig} */
+const isProd = process.env.NODE_ENV === 'production';
+
+const repoName = 'google-fit-steps'; // GitHubリポジトリ名
+
+const nextConfig = {
+  output: 'export',
+  // GitHub Pages用にbasePath/assetPrefixを設定
+  basePath: isProd ? `/${repoName}` : '',
+  assetPrefix: isProd ? `/${repoName}/` : '',
+  // 404.html出力
+  trailingSlash: true,
+};
+
+module.exports = nextConfig;

--- a/src/app/auth-debug/page.tsx
+++ b/src/app/auth-debug/page.tsx
@@ -44,7 +44,9 @@ export default function AuthTokenDebugPage() {
                     下記URLにアクセスし、認証後codeを取得
                     <br />
                     <code className="block break-all bg-base-200 p-2 my-2">
-                        https://accounts.google.com/o/oauth2/v2/auth?client_id=【GOOGLE_CLIENT_ID】&amp;redirect_uri={origin}/auth-debug&amp;response_type=code&amp;scope=https://www.googleapis.com/auth/fitness.activity.read&amp;access_type=offline&amp;prompt=consent
+                        https://accounts.google.com/o/oauth2/v2/auth?client_id=【GOOGLE_CLIENT_ID】&amp;redirect_uri=
+                        {origin}
+                        /auth-debug&amp;response_type=code&amp;scope=https://www.googleapis.com/auth/fitness.activity.read&amp;access_type=offline&amp;prompt=consent
                     </code>
                 </li>
                 <li>認証後このページにリダイレクトされ、トークンが表示されます</li>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,9 @@
+// 404.html for GitHub Pages static export
+export default function NotFound() {
+  return (
+    <main className="flex flex-col items-center justify-center min-h-screen">
+      <h1 className="text-3xl font-bold mb-4">404 - Not Found</h1>
+      <p>ページが見つかりませんでした。</p>
+    </main>
+  );
+}


### PR DESCRIPTION
- next.config.jsでoutput: 'export'、basePath/assetPrefixを設定
- 404ページ追加
- READMEにGitHub Pages用デプロイ手順を追記
- #11

ご確認ください。