### PR TITLE
UI/UXリッチ化: 歩数表示テーブル部分をカード型デザインに刷新

### DIFF
--- a/src/components/StepsClientView.tsx
+++ b/src/components/StepsClientView.tsx
@@ -1,5 +1,6 @@
 "use client";
 import StepsChart, { StepData } from "./StepsChart";
+import { FaWalking } from "react-icons/fa";
 
 interface Props {
     steps: StepData[];
@@ -14,45 +15,32 @@ export default function StepsClientView({ steps }: Props) {
     });
 
     return (
-        <div className="w-full max-w-md">
+        <div className="w-full max-w-2xl mx-auto">
             <StepsChart data={steps} />
-            <div className="my-4">
-                <div className="overflow-x-auto">
-                    <table className="table table-zebra w-full">
-                        <thead>
-                            <tr>
-                                <th>日数（今日除く）</th>
-                                <th>合計歩数</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {sums.map((sum, i) => (
-                                <tr key={i}>
-                                    <td>{i + 1}日</td>
-                                    <td>{sum.toLocaleString()} 歩</td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
+            {/* 合算歩数カード */}
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 my-6">
+                {sums.map((sum, i) => (
+                    <div key={i} className="card bg-base-100 shadow-md border border-base-200 flex flex-col items-center p-4">
+                        <div className="flex items-center gap-2 mb-2">
+                            <span className="badge badge-primary text-xs px-2 py-1">{i + 1}日合計</span>
+                            <FaWalking className="text-primary text-lg" aria-label="歩数アイコン" />
+                        </div>
+                        <span className="text-xl font-bold text-primary-content">{sum.toLocaleString()}</span>
+                        <span className="text-xs text-base-content">歩</span>
+                    </div>
+                ))}
             </div>
-            <div className="overflow-x-auto mt-6">
-                <table className="table table-zebra w-full">
-                    <thead>
-                        <tr>
-                            <th>日付</th>
-                            <th>歩数</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {steps.map((s, i) => (
-                            <tr key={i}>
-                                <td>{s.date}</td>
-                                <td>{s.steps.toLocaleString()}</td>
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
+            {/* 日別歩数カードリスト */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-8">
+                {steps.map((s, i) => (
+                    <div key={i} className="card bg-base-200 shadow flex flex-row items-center p-4 gap-4">
+                        <FaWalking className="text-accent text-2xl" aria-label="歩数アイコン" />
+                        <div className="flex flex-col">
+                            <span className="text-sm text-base-content/70">{s.date}</span>
+                            <span className="text-lg font-semibold text-accent-content">{s.steps.toLocaleString()} <span className="text-xs">歩</span></span>
+                        </div>
+                    </div>
+                ))}
             </div>
         </div>
     );


### PR DESCRIPTION
- 合算歩数・日別歩数ともにテーブル表示を廃止し、daisyUIカード＋バッジ＋アイコン（react-icons）によるリッチなUIに刷新
- レスポンシブ対応・アクセシビリティ考慮
- Issue #15 対応