### PR TITLE
Cloudflare Pagesで常に最新のGoogle Fit歩数データを取得できるようキャッシュ無効化対応

### DIFF
--- a/src/lib/fetchGoogleFitStepsFixedAccount.ts
+++ b/src/lib/fetchGoogleFitStepsFixedAccount.ts
@@ -2,45 +2,48 @@ import { StepData } from "../components/StepsChart";
 import { getGoogleFitAccessToken } from "./getGoogleFitAccessToken";
 
 export async function fetchGoogleFitStepsFixedAccount(): Promise<StepData[]> {
-  const accessToken = await getGoogleFitAccessToken();
-  // ...既存のGoogle Fit API呼び出しロジック...
-  const endpoint = "https://www.googleapis.com/fitness/v1/users/me/dataset:aggregate";
-  const now = new Date();
-  const endTimeMillis = now.getTime();
-  const start = new Date(now);
-  start.setDate(now.getDate() - 6);
-  start.setHours(0, 0, 0, 0);
-  const startTimeMillis = start.getTime();
-  const body = {
-    aggregateBy: [
-      {
-        dataTypeName: "com.google.step_count.delta",
-        dataSourceId: "derived:com.google.step_count.delta:com.google.android.gms:estimated_steps",
-      },
-    ],
-    bucketByTime: { durationMillis: 24 * 60 * 60 * 1000 },
-    startTimeMillis,
-    endTimeMillis,
-  };
-  const res = await fetch(endpoint, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-    next: { revalidate: 3600 },
-  });
-  if (!res.ok) throw new Error("Failed to fetch Google Fit steps");
-  const json = await res.json();
-  const steps: StepData[] = (json.bucket || []).map((bucket: Record<string, unknown>) => {
-    const date = new Date(Number(bucket.startTimeMillis));
-    const dataset = bucket.dataset as Array<{ point: Array<{ value: Array<{ intVal: number }> }> }>;
-    const count = dataset?.[0]?.point?.[0]?.value?.[0]?.intVal ?? 0;
-    return {
-      date: date.toLocaleDateString(),
-      steps: count,
+    const accessToken = await getGoogleFitAccessToken();
+    // ...既存のGoogle Fit API呼び出しロジック...
+    const endpoint = "https://www.googleapis.com/fitness/v1/users/me/dataset:aggregate";
+    const now = new Date();
+    const endTimeMillis = now.getTime();
+    const start = new Date(now);
+    start.setDate(now.getDate() - 6);
+    start.setHours(0, 0, 0, 0);
+    const startTimeMillis = start.getTime();
+    const body = {
+        aggregateBy: [
+            {
+                dataTypeName: "com.google.step_count.delta",
+                dataSourceId:
+                    "derived:com.google.step_count.delta:com.google.android.gms:estimated_steps",
+            },
+        ],
+        bucketByTime: { durationMillis: 24 * 60 * 60 * 1000 },
+        startTimeMillis,
+        endTimeMillis,
     };
-  });
-  return steps;
+    const res = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+            "Cache-Control": "no-store", // キャッシュ無効化
+        },
+        body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error("Failed to fetch Google Fit steps");
+    const json = await res.json();
+    const steps: StepData[] = (json.bucket || []).map((bucket: Record<string, unknown>) => {
+        const date = new Date(Number(bucket.startTimeMillis));
+        const dataset = bucket.dataset as Array<{
+            point: Array<{ value: Array<{ intVal: number }> }>;
+        }>;
+        const count = dataset?.[0]?.point?.[0]?.value?.[0]?.intVal ?? 0;
+        return {
+            date: date.toLocaleDateString(),
+            steps: count,
+        };
+    });
+    return steps;
 }


### PR DESCRIPTION
 #25

Cloudflare PagesでGoogle Fit歩数データがキャッシュされて最新にならない問題への対応です。
- fetchのnext: { revalidate: ... }を削除
- fetchリクエストヘッダーにCache-Control: no-storeを追加

これによりCloudflare Pages上でも毎回Google Fit APIへアクセスし、常に最新データを取得できます。